### PR TITLE
Fix compilation for latest compiler version

### DIFF
--- a/src/main/mod.rs
+++ b/src/main/mod.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 use github_star_counter::{count_stars, Error, Options};
 use simple_logger;
 use std::io::stdout;
@@ -11,7 +10,6 @@ async fn main() -> Result<(), Error> {
     use options::Args;
 
     let args: Args = Args::from_args();
-    let name = args.username.clone();
     simple_logger::init_with_level(args.log_level).ok();
-    count_stars(&name, stdout(), args.into()).await
+    count_stars(&args.username.clone(), stdout(), args.into()).await
 }


### PR DESCRIPTION
The compilation did not work on
v1.39.0-nightly. Namely, we run into ownership
problems with the `name` argument.
A quick workaround is executing `clone()` on the
argument before passing it to `count_stars`.

On top of that, ` #![feature(async_await)] ` is no
longer explicitly necessary.