### PR TITLE
Add tokio `full` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.40"
 itertools = "0.8.0"
 futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
-tokio = "0.2.0-alpha.6"
+tokio = { version = "0.2.1", features = ["full"] }
 base64 = "0.11"
 lazy_static = "1.3.0"
 log = "0.4.8"


### PR DESCRIPTION
As of tokio 0.2, features are hidden behind flags.
For example, macros require the `macro` feature.
See https://github.com/tokio-rs/tokio/issues/1833
for a more detailed description.

The easiest way to stay up-to-date is by enabling
the `full` feature flag, which is analog to the
previous behavior. This fixes `cargo install`.